### PR TITLE
Fixed translation direction/capitalization for class, struct, and void

### DIFF
--- a/word.cpp
+++ b/word.cpp
@@ -177,14 +177,14 @@ void Word::translate_word()
                 out << "float";
         else if (word == "doble")
                 out << "double";
-        else if (word == "Class")
-                out << "Clase";
-        else if (word == "struct")
-                out << "estruct";
+        else if (word == "clase")
+                out << "class";
+        else if (word == "estruct")
+                out << "struct";
         else if (word == "no_signo")
                 out << "unsigned";
-        else if (word == "void")
-                out << "vacío";
+        else if (word == "vacío")
+                out << "void";
        
         /* flow control */
         else if (word == "si")


### PR DESCRIPTION
I don't know much Spanish but I'm fairly certain these needed fixing anyway.
